### PR TITLE
Add gradle.lockfile parser for Gradle dependency locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All available config options are in: https://github.com/ecosyste-ms/bibliothecar
   - sbt-update-full.txt
   - maven-dependency-tree.txt
   - maven-dependency-tree.dot
+  - gradle.lockfile
 - RubyGems
   - Gemfile
   - Gemfile.lock

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -130,6 +130,12 @@ module Bibliothecary
             kind: "lockfile",
             parser: :parse_maven_tree_dot,
           },
+          # gradle.lockfile is the output of Gradle dependency locking:
+          # https://docs.gradle.org/current/userguide/dependency_locking.html
+          match_filename("gradle.lockfile", case_insensitive: true) => {
+            kind: "lockfile",
+            parser: :parse_gradle_lockfile,
+          },
         }
       end
 
@@ -411,6 +417,40 @@ module Bibliothecary
           dependencies: deps,
           project_name: project_name
         )
+      end
+
+      def self.parse_gradle_lockfile(file_contents, options: {})
+        source = options.fetch(:filename, nil)
+        deps = []
+
+        file_contents.each_line do |line|
+          line = line.strip
+          # Skip comments and empty lines
+          next if line.empty? || line.start_with?("#")
+
+          # Format: group:artifact:version=configurations
+          # Split on = first to separate the GAV from configurations
+          gav_part = line.split("=").first
+          next unless gav_part
+
+          parts = gav_part.split(":")
+          # Must have exactly 3 parts: group, artifact, version
+          next unless parts.length == 3
+
+          group, artifact, version = parts
+          # Skip empty entries (like "empty=")
+          next if version.nil? || version.empty?
+
+          deps << Dependency.new(
+            name: "#{group}:#{artifact}",
+            requirement: version,
+            type: "runtime",
+            source: source,
+            platform: platform_name
+          )
+        end
+
+        ParserResult.new(dependencies: deps)
       end
 
       def self.parse_resolved_dep_line(line, options: {})

--- a/spec/fixtures/gradle.lockfile
+++ b/spec/fixtures/gradle.lockfile
@@ -1,0 +1,10 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.springframework.security:spring-security-crypto:5.7.3=compileClasspath,productionRuntimeClasspath,runtimeClasspath
+org.springframework:spring-core:5.3.23=compileClasspath,productionRuntimeClasspath,runtimeClasspath
+org.springframework:spring-jcl:5.3.23=compileClasspath,productionRuntimeClasspath,runtimeClasspath
+com.google.guava:guava:31.1-jre=compileClasspath,runtimeClasspath
+org.slf4j:slf4j-api:2.0.6=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.9.2=testCompileClasspath,testRuntimeClasspath
+empty=

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -828,6 +828,23 @@ RSpec.describe Bibliothecary::Parsers::Maven do
       expect(guavas.length).to eq 1
       expect(guavas[0].requirement).to eq "30.1.1-jre"
     end
+
+    it "parses dependencies from gradle.lockfile" do
+      deps = described_class.analyse_contents("gradle.lockfile", load_fixture("gradle.lockfile"))
+      expect(deps[:kind]).to eq "lockfile"
+      expect(deps[:dependencies]).to match_array([
+        Bibliothecary::Dependency.new(platform: "maven", name: "org.springframework.security:spring-security-crypto", requirement: "5.7.3", type: "runtime", source: "gradle.lockfile"),
+        Bibliothecary::Dependency.new(platform: "maven", name: "org.springframework:spring-core", requirement: "5.3.23", type: "runtime", source: "gradle.lockfile"),
+        Bibliothecary::Dependency.new(platform: "maven", name: "org.springframework:spring-jcl", requirement: "5.3.23", type: "runtime", source: "gradle.lockfile"),
+        Bibliothecary::Dependency.new(platform: "maven", name: "com.google.guava:guava", requirement: "31.1-jre", type: "runtime", source: "gradle.lockfile"),
+        Bibliothecary::Dependency.new(platform: "maven", name: "org.slf4j:slf4j-api", requirement: "2.0.6", type: "runtime", source: "gradle.lockfile"),
+        Bibliothecary::Dependency.new(platform: "maven", name: "org.junit.jupiter:junit-jupiter-api", requirement: "5.9.2", type: "runtime", source: "gradle.lockfile"),
+      ])
+    end
+
+    it "matches gradle.lockfile filepath" do
+      expect(described_class.match?("gradle.lockfile")).to be_truthy
+    end
   end
 
   describe "parse_pom_manifests" do


### PR DESCRIPTION
- Add parse_gradle_lockfile method to maven.rb parser
- Parse group:artifact:version format from lockfiles
- Add test fixture and specs