### PR TITLE
Add LuaRocks parser for Lua package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ All available config options are in: https://github.com/ecosyste-ms/bibliothecar
   - Modelfile
 - Nimble
   - \*.nimble
+- LuaRocks
+  - \*.rockspec
 
 ## Development
 

--- a/lib/bibliothecary/parsers/luarocks.rb
+++ b/lib/bibliothecary/parsers/luarocks.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Bibliothecary
+  module Parsers
+    class LuaRocks
+      include Bibliothecary::Analyser
+
+      def self.mapping
+        {
+          match_extension(".rockspec") => {
+            kind: "manifest",
+            parser: :parse_rockspec,
+          },
+        }
+      end
+
+      def self.parse_rockspec(file_contents, options: {})
+        source = options.fetch(:filename, nil)
+        deps = []
+
+        # Find dependencies table in Lua format
+        # dependencies = { "lua >= 5.1", "package ~> 1.0" }
+        if file_contents =~ /dependencies\s*=\s*\{([^}]*)\}/m
+          deps_block = Regexp.last_match(1)
+
+          # Extract quoted strings from the dependencies table
+          deps_block.scan(/"([^"]+)"/).flatten.each do |spec|
+            spec = spec.strip
+            next if spec.empty?
+
+            # Parse "packagename" or "packagename >= version" or "packagename ~> version"
+            # Format: name [operator version]
+            if spec =~ /^([a-zA-Z0-9_-]+)\s*(.*)$/
+              name = Regexp.last_match(1)
+              requirement = Regexp.last_match(2).strip
+              requirement = "*" if requirement.empty?
+
+              deps << Dependency.new(
+                name: name,
+                requirement: requirement,
+                type: "runtime",
+                source: source,
+                platform: platform_name
+              )
+            end
+          end
+        end
+
+        ParserResult.new(dependencies: deps)
+      end
+    end
+  end
+end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -31,6 +31,7 @@ describe Bibliothecary do
           Bibliothecary::Parsers::Hex,
           Bibliothecary::Parsers::Homebrew,
           Bibliothecary::Parsers::Julia,
+          Bibliothecary::Parsers::LuaRocks,
           Bibliothecary::Parsers::Maven,
           Bibliothecary::Parsers::Meteor,
           Bibliothecary::Parsers::MLflow,

--- a/spec/fixtures/example.rockspec
+++ b/spec/fixtures/example.rockspec
@@ -1,0 +1,26 @@
+package = "example"
+version = "1.0.0-1"
+source = {
+   url = "git://github.com/example/example.git",
+   tag = "v1.0.0"
+}
+description = {
+   summary = "An example Lua package",
+   detailed = [[
+      This is an example package.
+   ]],
+   homepage = "https://github.com/example/example",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1",
+   "luafilesystem >= 1.8.0",
+   "lpeg ~> 1.0",
+   "luasocket"
+}
+build = {
+   type = "builtin",
+   modules = {
+      example = "src/example.lua"
+   }
+}

--- a/spec/parsers/luarocks_spec.rb
+++ b/spec/parsers/luarocks_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Bibliothecary::Parsers::LuaRocks do
+  it "has a platform name" do
+    expect(described_class.platform_name).to eq("luarocks")
+  end
+
+  it "parses dependencies from .rockspec files" do
+    expect(described_class.analyse_contents("example.rockspec", load_fixture("example.rockspec"))).to eq({
+      platform: "luarocks",
+      path: "example.rockspec",
+      project_name: nil,
+      dependencies: [
+        Bibliothecary::Dependency.new(platform: "luarocks", name: "lua", requirement: ">= 5.1", type: "runtime", source: "example.rockspec"),
+        Bibliothecary::Dependency.new(platform: "luarocks", name: "luafilesystem", requirement: ">= 1.8.0", type: "runtime", source: "example.rockspec"),
+        Bibliothecary::Dependency.new(platform: "luarocks", name: "lpeg", requirement: "~> 1.0", type: "runtime", source: "example.rockspec"),
+        Bibliothecary::Dependency.new(platform: "luarocks", name: "luasocket", requirement: "*", type: "runtime", source: "example.rockspec"),
+      ],
+      kind: "manifest",
+      success: true,
+    })
+  end
+
+  it "matches valid manifest filepaths" do
+    expect(described_class.match?("example.rockspec")).to be_truthy
+    expect(described_class.match?("mypackage-1.0.0-1.rockspec")).to be_truthy
+  end
+
+  it "doesn't match invalid manifest filepaths" do
+    expect(described_class.match?("package.json")).to be_falsey
+    expect(described_class.match?("rocks.lock")).to be_falsey
+  end
+end


### PR DESCRIPTION
- Create new luarocks.rb parser for .rockspec files
- Parse dependencies table from Lua rockspec format
- Handle version constraints (~>, >=, etc.)
- Add test fixture and specs