### PR TITLE
Add verification-metadata.xml parser for Gradle dependency verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ All available config options are in: https://github.com/ecosyste-ms/bibliothecar
   - maven-dependency-tree.txt
   - maven-dependency-tree.dot
   - gradle.lockfile
+  - verification-metadata.xml
 - RubyGems
   - Gemfile
   - Gemfile.lock

--- a/lib/bibliothecary/parsers/maven.rb
+++ b/lib/bibliothecary/parsers/maven.rb
@@ -136,6 +136,12 @@ module Bibliothecary
             kind: "lockfile",
             parser: :parse_gradle_lockfile,
           },
+          # gradle/verification-metadata.xml is used by Gradle for dependency verification
+          # https://docs.gradle.org/current/userguide/dependency_verification.html
+          match_filename("verification-metadata.xml", case_insensitive: true) => {
+            kind: "lockfile",
+            parser: :parse_gradle_verification_metadata,
+          },
         }
       end
 
@@ -443,6 +449,34 @@ module Bibliothecary
 
           deps << Dependency.new(
             name: "#{group}:#{artifact}",
+            requirement: version,
+            type: "runtime",
+            source: source,
+            platform: platform_name
+          )
+        end
+
+        ParserResult.new(dependencies: deps)
+      end
+
+      def self.parse_gradle_verification_metadata(file_contents, options: {})
+        source = options.fetch(:filename, nil)
+        deps = []
+
+        doc = Ox.parse(file_contents)
+        components = doc.locate("verification-metadata/components/component")
+
+        components.each do |component|
+          attrs = component.attributes
+          group = attrs[:group]
+          name = attrs[:name]
+          version = attrs[:version]
+
+          next if group.nil? || name.nil? || version.nil?
+          next if group.empty? || name.empty? || version.empty?
+
+          deps << Dependency.new(
+            name: "#{group}:#{name}",
             requirement: version,
             type: "runtime",
             source: source,

--- a/spec/fixtures/gradle/verification-metadata.xml
+++ b/spec/fixtures/gradle/verification-metadata.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata xmlns="https://schema.gradle.org/dependency-verification"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.3.xsd">
+  <configuration>
+    <verify-metadata>true</verify-metadata>
+    <verify-signatures>false</verify-signatures>
+  </configuration>
+  <components>
+    <component group="org.apache.pdfbox" name="pdfbox" version="2.0.17">
+      <artifact name="pdfbox-2.0.17.jar">
+        <sha512 value="7e11e54a21c395d461e59552e88b0de0ebaf1bf9d9bcacadf17b240d9bbc29bf6beb8e36896c186fe405d287f5d517b02c89381aa0fcc5e0aa5814e44f0ab331"/>
+      </artifact>
+    </component>
+    <component group="com.github.javaparser" name="javaparser-core" version="3.6.11">
+      <artifact name="javaparser-core-3.6.11.jar">
+        <pgp value="8756c4f765c9ac3cb6b85d62379ce192d401ab61"/>
+      </artifact>
+    </component>
+    <component group="org.springframework" name="spring-core" version="5.3.23">
+      <artifact name="spring-core-5.3.23.jar">
+        <sha256 value="abc123"/>
+      </artifact>
+    </component>
+  </components>
+</verification-metadata>

--- a/spec/parsers/maven_spec.rb
+++ b/spec/parsers/maven_spec.rb
@@ -845,6 +845,21 @@ RSpec.describe Bibliothecary::Parsers::Maven do
     it "matches gradle.lockfile filepath" do
       expect(described_class.match?("gradle.lockfile")).to be_truthy
     end
+
+    it "parses dependencies from verification-metadata.xml" do
+      deps = described_class.analyse_contents("verification-metadata.xml", load_fixture("gradle/verification-metadata.xml"))
+      expect(deps[:kind]).to eq "lockfile"
+      expect(deps[:dependencies]).to match_array([
+        Bibliothecary::Dependency.new(platform: "maven", name: "org.apache.pdfbox:pdfbox", requirement: "2.0.17", type: "runtime", source: "verification-metadata.xml"),
+        Bibliothecary::Dependency.new(platform: "maven", name: "com.github.javaparser:javaparser-core", requirement: "3.6.11", type: "runtime", source: "verification-metadata.xml"),
+        Bibliothecary::Dependency.new(platform: "maven", name: "org.springframework:spring-core", requirement: "5.3.23", type: "runtime", source: "verification-metadata.xml"),
+      ])
+    end
+
+    it "matches verification-metadata.xml filepath" do
+      expect(described_class.match?("verification-metadata.xml")).to be_truthy
+      expect(described_class.match?("gradle/verification-metadata.xml")).to be_truthy
+    end
   end
 
   describe "parse_pom_manifests" do


### PR DESCRIPTION
- Add parse_gradle_verification_metadata method to maven.rb parser
- Parse component group:name:version from verification XML
- Add test fixture and specs