### PR TITLE
Add .deps.json parser for .NET runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ All available config options are in: https://github.com/ecosyste-ms/bibliothecar
   - paket.lock
   - *.csproj
   - project.assets.json
+  - \*.deps.json
 - Bower
   - bower.json
 - BentoML

--- a/lib/bibliothecary/parsers/nuget.rb
+++ b/lib/bibliothecary/parsers/nuget.rb
@@ -42,6 +42,11 @@ module Bibliothecary
             kind: "lockfile",
             parser: :parse_project_assets_json,
           },
+          # .deps.json files end with .deps.json (e.g. myapp.deps.json)
+          match_extension(".deps.json") => {
+            kind: "lockfile",
+            parser: :parse_deps_json,
+          },
         }
       end
 
@@ -245,6 +250,33 @@ module Bibliothecary
           return ParserResult.new(dependencies: frameworks[frameworks.keys.max]) unless frameworks.empty?
         end
         ParserResult.new(dependencies: [])
+      end
+
+      def self.parse_deps_json(file_contents, options: {})
+        manifest = JSON.parse(file_contents)
+        libraries = manifest.fetch("libraries", {})
+
+        dependencies = libraries.map do |name_version, details|
+          # Skip project-type entries (these are the root/main package)
+          next if details["type"] == "project"
+
+          # Split name/version format
+          parts = name_version.split("/")
+          next unless parts.length == 2
+
+          name, version = parts
+          next if name.nil? || name.empty? || version.nil? || version.empty?
+
+          Dependency.new(
+            name: name,
+            requirement: version,
+            type: "runtime",
+            source: options.fetch(:filename, nil),
+            platform: platform_name
+          )
+        end.compact
+
+        ParserResult.new(dependencies: dependencies)
       end
     end
   end

--- a/spec/fixtures/example.deps.json
+++ b/spec/fixtures/example.deps.json
@@ -1,0 +1,35 @@
+{
+  "runtimeTarget": {
+    "name": ".NETCoreApp,Version=v6.0",
+    "signature": ""
+  },
+  "compilationOptions": {},
+  "libraries": {
+    "MyApp/1.0.0": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Newtonsoft.Json/13.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ppPFpBcvxdsfUon7g7o+4/7SQXUz0MgZH74+YbS3cJVQ=",
+      "path": "newtonsoft.json/13.0.1",
+      "hashPath": "newtonsoft.json.13.0.1.nupkg.sha512"
+    },
+    "Microsoft.Extensions.DependencyInjection/6.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA=",
+      "path": "microsoft.extensions.dependencyinjection/6.0.0",
+      "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
+    },
+    "Serilog/2.10.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-qXthQV2TUZVfUAPe8LZTYtZYQ3XqY6E+3wgjqZMrwxg=",
+      "path": "serilog/2.10.0",
+      "hashPath": "serilog.2.10.0.nupkg.sha512"
+    }
+  }
+}

--- a/spec/parsers/nuget_spec.rb
+++ b/spec/parsers/nuget_spec.rb
@@ -672,4 +672,24 @@ describe Bibliothecary::Parsers::Nuget do
     expect(described_class.match?("example.csproj")).to be_truthy
     expect(described_class.match?("project.assets.json")).to be_truthy
   end
+
+  it "parses dependencies from .deps.json" do
+    expect(described_class.analyse_contents("example.deps.json", load_fixture("example.deps.json"))).to eq({
+      platform: "nuget",
+      path: "example.deps.json",
+      project_name: nil,
+      dependencies: [
+        Bibliothecary::Dependency.new(platform: "nuget", name: "Newtonsoft.Json", requirement: "13.0.1", type: "runtime", source: "example.deps.json"),
+        Bibliothecary::Dependency.new(platform: "nuget", name: "Microsoft.Extensions.DependencyInjection", requirement: "6.0.0", type: "runtime", source: "example.deps.json"),
+        Bibliothecary::Dependency.new(platform: "nuget", name: "Serilog", requirement: "2.10.0", type: "runtime", source: "example.deps.json"),
+      ],
+      kind: "lockfile",
+      success: true,
+    })
+  end
+
+  it "matches .deps.json filepath" do
+    expect(described_class.match?("myapp.deps.json")).to be_truthy
+    expect(described_class.match?("example.deps.json")).to be_truthy
+  end
 end


### PR DESCRIPTION
- Add parse_deps_json method to nuget.rb parser
- Parse libraries from .deps.json files (skip project entries)
- Match files ending in .deps.json
- Add test fixture and specs