### PR TITLE
Add renv.lock parser for R package management

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ All available config options are in: https://github.com/ecosyste-ms/bibliothecar
   - MLmodel
 - CRAN
   - DESCRIPTION
+  - renv.lock
 - Cargo
   - Cargo.toml
   - Cargo.lock

--- a/lib/bibliothecary/parsers/cran.rb
+++ b/lib/bibliothecary/parsers/cran.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 module Bibliothecary
   module Parsers
     class CRAN
@@ -12,6 +14,10 @@ module Bibliothecary
           match_filename("DESCRIPTION", case_insensitive: true) => {
             kind: "manifest",
             parser: :parse_description,
+          },
+          match_filename("renv.lock") => {
+            kind: "lockfile",
+            parser: :parse_renv_lock,
           },
         }
       end
@@ -66,6 +72,29 @@ module Bibliothecary
             platform: platform_name
           )
         end.compact
+      end
+
+      def self.parse_renv_lock(file_contents, options: {})
+        source = options.fetch(:filename, nil)
+        manifest = JSON.parse(file_contents)
+        packages = manifest.fetch("Packages", {})
+
+        dependencies = packages.map do |_key, pkg|
+          # Only include packages from CRAN repository
+          # Skip local packages and packages from other sources like Bioconductor
+          repository = pkg["Repository"]
+          next unless repository == "CRAN"
+
+          Dependency.new(
+            name: pkg["Package"],
+            requirement: pkg["Version"],
+            type: "runtime",
+            source: source,
+            platform: platform_name
+          )
+        end.compact
+
+        ParserResult.new(dependencies: dependencies)
       end
     end
   end

--- a/spec/fixtures/renv.lock
+++ b/spec/fixtures/renv.lock
@@ -1,0 +1,96 @@
+{
+  "R": {
+    "Version": "4.3.2",
+    "Repositories": [
+      {
+        "Name": "CRAN",
+        "URL": "https://cloud.r-project.org"
+      }
+    ]
+  },
+  "Packages": {
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "1.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "generics",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "methods",
+        "pillar",
+        "R6",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "597b74c671d8bffb59c3aa51e8f7db53"
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "MASS",
+        "R",
+        "cli",
+        "glue",
+        "grDevices",
+        "grid",
+        "gtable",
+        "isoband",
+        "lifecycle",
+        "mgcv",
+        "rlang",
+        "scales",
+        "stats",
+        "tibble",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "e3c4d693c5c82602ea6c9ff5583c32ad"
+    },
+    "tidyr": {
+      "Package": "tidyr",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "cpp11",
+        "dplyr",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "stringr",
+        "tibble",
+        "tidyselect",
+        "utils",
+        "vctrs"
+      ],
+      "Hash": "8fdd7c61b8f83a8b1a5a1cec8e1d7dcc"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "2.25",
+      "Source": "Repository",
+      "Repository": "Bioconductor",
+      "Hash": "88a70f9d3e5e5b3e5e5e5e5e5e5e5e5e"
+    },
+    "localpackage": {
+      "Package": "localpackage",
+      "Version": "0.1.0",
+      "Source": "Local"
+    }
+  }
+}

--- a/spec/parsers/cran_spec.rb
+++ b/spec/parsers/cran_spec.rb
@@ -81,4 +81,23 @@ describe Bibliothecary::Parsers::CRAN do
   it "matches valid manifest filepaths" do
     expect(described_class.match?("DESCRIPTION")).to be_truthy
   end
+
+  it "parses dependencies from renv.lock" do
+    expect(described_class.analyse_contents("renv.lock", load_fixture("renv.lock"))).to eq({
+      platform: "cran",
+      path: "renv.lock",
+      project_name: nil,
+      dependencies: [
+        Bibliothecary::Dependency.new(platform: "cran", name: "dplyr", requirement: "1.1.4", type: "runtime", source: "renv.lock"),
+        Bibliothecary::Dependency.new(platform: "cran", name: "ggplot2", requirement: "3.4.4", type: "runtime", source: "renv.lock"),
+        Bibliothecary::Dependency.new(platform: "cran", name: "tidyr", requirement: "1.3.0", type: "runtime", source: "renv.lock"),
+      ],
+      kind: "lockfile",
+      success: true
+    })
+  end
+
+  it "matches renv.lock filepath" do
+    expect(described_class.match?("renv.lock")).to be_truthy
+  end
 end


### PR DESCRIPTION
- Add parse_renv_lock method to cran.rb parser
- Only include packages from CRAN repository (skip Bioconductor, local)
- Add test fixture and specs