### PR TITLE
Add Bazel MODULE.bazel manifests parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [15.4.0]
+
+- Parser for MODULE.bazel manifests
+
+### Added
+
 ## [15.3.0]
 
 ### Added
@@ -158,7 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Bibliothecary::ParserResult class, which wraps the parsed dependencies along with the project name, if it was found in the manifest. 
+- Added Bibliothecary::ParserResult class, which wraps the parsed dependencies along with the project name, if it was found in the manifest.
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    ecosystems-bibliothecary (15.3.0)
+    ecosystems-bibliothecary (15.4.0)
       bundler
       csv
       json (~> 2.8)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bibliothecary
 
-Dependency manifest parsing library for https://github.com/ecosyste-ms 
+Dependency manifest parsing library for https://github.com/ecosyste-ms
 
 This is a maintained fork of the original [Bibliothecary](https://github.com/librariesio/bibliothecary) gem, with support for additional manifest formats and bug fixes.
 
@@ -98,6 +98,8 @@ The `integrity` field is populated for lockfiles that include per-dependency has
   - environment.yaml
 - Apk
   - APKBUILD
+- Bazel
+  - MODULE.bazel
 - BentoML
   - bentofile.yaml
 - Bower

--- a/lib/bibliothecary/parsers/bazel.rb
+++ b/lib/bibliothecary/parsers/bazel.rb
@@ -1,0 +1,67 @@
+module Bibliothecary
+  module Parsers
+    class Bazel
+      include Bibliothecary::Analyser
+
+      BAZEL_DEP_STATEMENT = %r{
+        ^\s*bazel_dep\s*
+        (?<bal>
+          \(
+            (?:
+              [^()"'\\]+
+              | "(?:\\.|[^"\\])*"
+              | '(?:\\.|[^'\\])*'
+              | \\ .
+              | \g<bal>
+            )*
+          \)
+        )
+      }mx
+
+      # key/value extraction inside the call
+      DEPENDENCY_NAME    = /(?:^|[,(]\s*)name\s*=\s*(?<quote>["'])(?<value>(?:\\.|(?!\k<quote>).)*)\k<quote>/m
+      DEPENDENCY_VERSION = /(?:^|[,(]\s*)version\s*=\s*(?<quote>["'])(?<value>(?:\\.|(?!\k<quote>).)*)\k<quote>/m
+      DEPENDENCY_TYPE     = /(?:^|[,(]\s*)dev_dependency\s*=\s*(?<value>True|False)\b/m
+
+
+      def self.file_patterns
+        ["MODULE.bazel"]
+      end
+
+      def self.mapping
+        {
+          match_filename("MODULE.bazel") => {
+            kind: "manifest",
+            parser: :parse_module_bazel,
+          }
+        }
+      end
+
+      def self.parse_module_bazel(file_contents, options: {})
+        source = options.fetch(:filename, nil)
+
+        dependencies = file_contents.scan(BAZEL_DEP_STATEMENT).map do |(statement)|
+          name = statement.match(DEPENDENCY_NAME)[:value]
+          parsed_version = statement.match(DEPENDENCY_VERSION)
+          parsed_type = statement.match(DEPENDENCY_TYPE)
+          version = parsed_version ? parsed_version[:value] : '*'
+          type =
+            if parsed_type && parsed_type[:value] == "True"
+              "development"
+            else
+              "runtime"
+            end
+
+          Dependency.new(
+            platform: platform_name,
+            name: name,
+            requirement: version,
+            type: type,
+            source: source,
+          )
+        end
+        ParserResult.new(dependencies: dependencies)
+      end
+    end
+  end
+end

--- a/lib/bibliothecary/version.rb
+++ b/lib/bibliothecary/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bibliothecary
-  VERSION = "15.3.0"
+  VERSION = "15.4.0"
 end

--- a/spec/bibliothecary_spec.rb
+++ b/spec/bibliothecary_spec.rb
@@ -12,6 +12,7 @@ describe Bibliothecary do
           Bibliothecary::Parsers::Actions,
           Bibliothecary::Parsers::Alpm,
           Bibliothecary::Parsers::Apk,
+          Bibliothecary::Parsers::Bazel,
           Bibliothecary::Parsers::BentoML,
           Bibliothecary::Parsers::Bower,
           Bibliothecary::Parsers::Cargo,

--- a/spec/fixtures/MODULE.bazel
+++ b/spec/fixtures/MODULE.bazel
@@ -1,0 +1,61 @@
+module(name = "elemental2",
+    version = "1.3.0",
+)
+
+bazel_dep(name = "j2cl")
+
+# Use head j2cl for testing purposes.
+archive_override(
+    module_name = "j2cl",
+    strip_prefix = "j2cl-master",
+    urls = ["https://github.com/google/j2cl/archive/master.zip"],
+)
+
+bazel_dep(name = "jsinterop_generator", version = "20250812")
+
+# Use head jsinterop-generator for testing purposes.
+archive_override(
+    module_name = "jsinterop_generator",
+    strip_prefix = "jsinterop-generator-master",
+    urls = ["https://github.com/google/jsinterop-generator/archive/master.zip"],
+)
+
+bazel_dep(name = "jsinterop_base", version = "1.1.0")
+
+# Use head jsinterop-base for testing purposes.
+archive_override(
+    module_name = "jsinterop_base",
+    strip_prefix = "jsinterop-base-master",
+    urls = ["https://github.com/google/jsinterop-base/archive/master.zip"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "google_bazel_common", version = "0.0.1")
+bazel_dep(name = "rules_java", version = "8.13.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(
+    name = "google_benchmark",
+    version = "1.9.4",
+    dev_dependency = True,
+)
+
+# Maven dependencies.
+
+bazel_dep(name = "rules_jvm_external", version = "6.6")
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.artifact(
+    artifact = "closure-compiler",
+    group = "com.google.javascript",
+    version = "v20240317",
+)
+use_repo(maven, "maven")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "org_gwtproject_gwt",
+    sha256 = "731879b8e56024a34f36b83655975a474e1ac1dffdfe72724e337976ac0e1749",
+    strip_prefix = "gwt-073679594c6ead7abe501009f8ba31eb390047fc",
+    url = "https://github.com/gwtproject/gwt/archive/073679594c6ead7abe501009f8ba31eb390047fc.zip",
+)

--- a/spec/parsers/bazel_spec.rb
+++ b/spec/parsers/bazel_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Bibliothecary::Parsers::Bazel do
+  it "has a platform name" do
+    expect(described_class.platform_name).to eq("bazel")
+  end
+
+  it "parses dependencies from MODULE.bazel" do
+    expect(described_class.analyse_contents("MODULE.bazel", load_fixture("MODULE.bazel"))).to eq({
+                                                                                         platform: "bazel",
+                                                                                         path: "MODULE.bazel",
+                                                                                         project_name: nil,
+                                                                                         dependencies: [
+        Bibliothecary::Dependency.new(platform: "bazel", name: "j2cl", requirement: "*", type: "runtime", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "jsinterop_generator", requirement: "20250812", type: "runtime", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "jsinterop_base", requirement: "1.1.0", type: "runtime", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "bazel_skylib", requirement: "1.7.1", type: "runtime", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "google_bazel_common", requirement: "0.0.1", type: "runtime", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "rules_java", requirement: "8.13.0", type: "runtime", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "rules_license", requirement: "1.0.0", type: "runtime", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "google_benchmark", requirement: "1.9.4", type: "development", source: "MODULE.bazel"),
+        Bibliothecary::Dependency.new(platform: "bazel", name: "rules_jvm_external", requirement: "6.6", type: "runtime", source: "MODULE.bazel"),
+      ],
+                                                                                         kind: "manifest",
+                                                                                         success: true,
+                                                                                       })
+  end
+  it "matches valid manifest filepaths" do
+    expect(described_class.match?("MODULE.bazel")).to be_truthy
+  end
+end


### PR DESCRIPTION
### Summary

This PR is to add a new parser for Bazel ecosystem. It contains logic to parse and extract dependencies data from the manifest that exists for every module in the Bazel ecosystem - `MODULE.bazel`. For more details about the Bazel modules check the official documentation [here](https://bazel.build/external/module#bazel_dep).

At this stage, the parser extracts dependencies declared via the top-level `bazel_dep(...)`. It is important to note that Bazel module manifests support additional directives (such as macros and extensions) that may declare dependencies indirectly. Because these constructs require Starlark evaluation, it is not possible to reliably determine the full dependency graph without actually building the module and resolving dependencies. For more information about supported directives, please, check the [following](https://bazel.build/rules/lib/globals/module) section in the official documentation.

As a result, this parser is intentionally conservative and may produce incomplete results in cases where dependencies are declared through macros or non-literal expressions.

### Linked PRs
https://github.com/ecosyste-ms/packages/pull/1415

@andrew I have updated the version of the gem. Sorry, in case it was premature!


